### PR TITLE
hotfix: img upload 

### DIFF
--- a/film-api/src/main/java/com/programmers/film/api/post/dto/common/OrderImageFileDto.java
+++ b/film-api/src/main/java/com/programmers/film/api/post/dto/common/OrderImageFileDto.java
@@ -1,12 +1,14 @@
 package com.programmers.film.api.post.dto.common;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class OrderImageFileDto { // must have : only one img
     private int imageOrder;
-    private MultipartFile image;
+    private String url;
 }

--- a/film-api/src/main/java/com/programmers/film/api/post/dto/request/CreatePostRequest.java
+++ b/film-api/src/main/java/com/programmers/film/api/post/dto/request/CreatePostRequest.java
@@ -3,6 +3,7 @@ package com.programmers.film.api.post.dto.request;
 import com.programmers.film.api.post.dto.common.OrderImageFileDto;
 import com.programmers.film.api.post.dto.common.PointDto;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import lombok.Builder;
 import lombok.Getter;
 import java.util.List;
@@ -28,4 +29,13 @@ public class CreatePostRequest {
     private String content;
 
     private Long authorUserId;
+
+    public void setImageFiles(String[] urls) {
+        List<OrderImageFileDto> temp = new ArrayList<>();
+        int i = 0;
+        for (String url : urls) {
+            temp.add(new OrderImageFileDto(i++, url));
+        }
+        this.imageFiles = temp;
+    }
 }

--- a/film-api/src/main/java/com/programmers/film/api/post/exception/PostCanNotOpenException.java
+++ b/film-api/src/main/java/com/programmers/film/api/post/exception/PostCanNotOpenException.java
@@ -6,6 +6,6 @@ import com.programmers.film.common.error.exception.EntityNotFoundException;
 public class PostCanNotOpenException extends EntityNotFoundException {
 
     public PostCanNotOpenException(String message) {
-        super(message, ErrorCode.HANDLE_ACCESS_DENIED);
+        super(message, ErrorCode.CLOSED_POST_ERROR);
     }
 }

--- a/film-api/src/main/java/com/programmers/film/api/post/service/PostService.java
+++ b/film-api/src/main/java/com/programmers/film/api/post/service/PostService.java
@@ -57,32 +57,7 @@ public class PostService {
         user.addAuthority(authority);
         authorityRepository.save(authority);
 
-        // img upload
-        List<String> ImgUrls = request.getImageFiles().stream()
-            .map(orderImageFileDto -> {
-                try {
-                    return s3Service.upload(orderImageFileDto.getImage());
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-                return null;
-            })
-            .toList();
 
-        PostImage postImage = null;
-        try {
-            String ImgUrl = ImgUrls.get(0);
-            PostImage draftPostImage = PostImage.builder()
-                .imageUrl(
-                    ImageUrl.builder()
-                        .originalSizeUrl(ImgUrl)
-                        .build()
-                )
-                .build();
-            postImage = postImageRepository.save(draftPostImage);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
 
         PostDetail draftPostDetail = PostDetail.builder()
             .id(post.getId())
@@ -91,8 +66,27 @@ public class PostService {
             .build();
         PostDetail postDetail = postDetailRepository.save(draftPostDetail);
 
+        // img upload
+        PostImage postImage = null;
+        try {
+            if(request.getImageFiles()!=null) {
+                String ImgUrl = request.getImageFiles().get(0).getUrl();
+                PostImage draftPostImage = PostImage.builder()
+                    .imageUrl(
+                        ImageUrl.builder()
+                            .originalSizeUrl(ImgUrl)
+                            .build()
+                    )
+                    .postDetail(postDetail)
+                    .build();
+                postImage = postImageRepository.save(draftPostImage);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         if(postImage != null) {
-            postDetail.addPostImage(postImage);
+            //postDetail.addPostImage(postImage);
         }
 
         return postConverter.postToCreatePostResponse(post);

--- a/film-common/src/main/java/com/programmers/film/common/error/ErrorCode.java
+++ b/film-common/src/main/java/com/programmers/film/common/error/ErrorCode.java
@@ -39,7 +39,9 @@ public enum ErrorCode {
     AUTHORITY_ERROR(400, "P006", "Authority Error"),
     AUTHOR_NICKNAME_ERROR(400, "P007", "Author Nickname Error"),
     IMAGE_ERROR(400, "P008", "Image Error"),
-    CONTENT_ERROR(400, "P009", "Content Error");
+    CONTENT_ERROR(400, "P009", "Content Error"),
+    CLOSED_POST_ERROR(403,"P010","POST Closed");
+
 
     private final int status;
     private final String code;

--- a/film-external/src/main/java/com/programmers/film/img/S3Service.java
+++ b/film-external/src/main/java/com/programmers/film/img/S3Service.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
 
 @Service
 @NoArgsConstructor
@@ -62,5 +63,14 @@ public class S3Service {
         } catch (StringIndexOutOfBoundsException e) {
             throw new IllegalArgumentException(String.format("잘못된 형식의 파일 (%s) 입니다", fileName));
         }
+    }
+
+    public String[] upload(List<MultipartFile> files) throws IOException {
+        String[] str = new String[files.size()];
+        int i = 0;
+        for (MultipartFile file : files) {
+            str[i++] = upload(file);
+        }
+        return str;
     }
 }


### PR DESCRIPTION
이미지 업로드 수정했습니다.
이미지가 없어도, 이미지가 여러장이여도 업로드 가능합니다.

must have 정책상 이미지는 1장만 넣어두기로 했기때문에 이미지는 1장만 업로드를 요구합니다.